### PR TITLE
Add CI for supported ROS distros

### DIFF
--- a/.github/workflows/kinetic.yaml
+++ b/.github/workflows/kinetic.yaml
@@ -1,0 +1,31 @@
+name: build-kinetic
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: kinetic, ROS_REPO: main, BUILDER: catkin_make, NOT_TEST_BUILD: true}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Clone core and remove CATKIN_IGNOREs
+        run: |
+          git clone https://github.com/Interbotix/interbotix_ros_core.git
+          rm interbotix_ros_core/interbotix_ros_xseries/CATKIN_IGNORE
+          rm interbotix_common_toolbox/interbotix_moveit_interface/CATKIN_IGNORE
+          rm interbotix_xs_toolbox/CATKIN_IGNORE
+      - name: Create src directory for xs
+        run: |
+          mkdir src
+          mv interbotix_ros_core src
+          mv interbotix_common_toolbox src
+          mv interbotix_xs_toolbox src
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/.github/workflows/melodic.yaml
+++ b/.github/workflows/melodic.yaml
@@ -1,0 +1,31 @@
+name: build-melodic
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: melodic, ROS_REPO: main, BUILDER: catkin_make, NOT_TEST_BUILD: true}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Clone core and remove CATKIN_IGNOREs
+        run: |
+          git clone https://github.com/Interbotix/interbotix_ros_core.git
+          rm interbotix_ros_core/interbotix_ros_xseries/CATKIN_IGNORE
+          rm interbotix_common_toolbox/interbotix_moveit_interface/CATKIN_IGNORE
+          rm interbotix_xs_toolbox/CATKIN_IGNORE
+      - name: Create src directory for xs
+        run: |
+          mkdir src
+          mv interbotix_ros_core src
+          mv interbotix_common_toolbox src
+          mv interbotix_xs_toolbox src
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/.github/workflows/noetic.yaml
+++ b/.github/workflows/noetic.yaml
@@ -1,0 +1,31 @@
+name: build-noetic
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: noetic,  ROS_REPO: main, BUILDER: catkin_make, NOT_TEST_BUILD: true}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Clone core and remove CATKIN_IGNOREs
+        run: |
+          git clone https://github.com/Interbotix/interbotix_ros_core.git
+          rm interbotix_ros_core/interbotix_ros_xseries/CATKIN_IGNORE
+          rm interbotix_common_toolbox/interbotix_moveit_interface/CATKIN_IGNORE
+          rm interbotix_xs_toolbox/CATKIN_IGNORE
+      - name: Create src directory for xs
+        run: |
+          mkdir src
+          mv interbotix_ros_core src
+          mv interbotix_common_toolbox src
+          mv interbotix_xs_toolbox src
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Links to other repositories that use this repo include:
 - [interbotix_ros_crawlers](https://github.com/Interbotix/interbotix_ros_crawlers)
 - [interbotix_ros_manipulators](https://github.com/Interbotix/interbotix_ros_manipulators)
 
+### Build Status
+![build-kinetic status](https://github.com/Interbotix/interbotix_ros_toolboxes/actions/workflows/kinetic.yaml/badge.svg)
+![build-melodic Status](https://github.com/Interbotix/interbotix_ros_toolboxes/actions/workflows/melodic.yaml/badge.svg)
+![build-noetic Status](https://github.com/Interbotix/interbotix_ros_toolboxes/actions/workflows/noetic.yaml/badge.svg)
+
 ## Repo Structure
 ```
 GitHub Landing Page: Explains repository structure and contains a single directory for each type of toolbox.


### PR DESCRIPTION
Use GitHub actions and ROS-Industrial CI to run continuous integration build tests. Continuous integration tests will come later for this repo.