### PR TITLE
[landmark_modules] Fix Python2/3 issues

### DIFF
--- a/interbotix_common_toolbox/interbotix_landmark_modules/package.xml
+++ b/interbotix_common_toolbox/interbotix_landmark_modules/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>interbotix_landmark_modules</name>
   <version>0.0.0</version>
   <description>The interbotix_landmark_modules package</description>
@@ -28,6 +28,8 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-six</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-six</exec_depend>
   
   <test_depend>rosunit</test_depend>
 

--- a/interbotix_common_toolbox/interbotix_landmark_modules/scripts/landmark_manager
+++ b/interbotix_common_toolbox/interbotix_landmark_modules/scripts/landmark_manager
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
+import six
 import rospy
 import rospkg
-import argparse
 from interbotix_landmark_modules.landmark import Landmark, LandmarkCollection
 
 
@@ -90,7 +90,7 @@ class LandmarkManagerCLI(object):
         """
         while True:
             try:
-                input_ = type_(raw_input(self.cursor))
+                input_ = type_(six.moves.input(self.cursor))
                 return input_
             except ValueError:
                 print("Please enter a value of {}".format(type_))


### PR DESCRIPTION
Fixed Python2/3 compatibility issue - replaced raw_input with six.moves.input. Added six to package exec_depend.