### PR TITLE
[perception_modules] Add back perception messages

### DIFF
--- a/interbotix_perception_toolbox/interbotix_perception_modules/CMakeLists.txt
+++ b/interbotix_perception_toolbox/interbotix_perception_modules/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   interbotix_xs_msgs
   apriltag_ros
   cv_bridge
+  message_generation
   pcl_conversions
   pcl_ros
   roscpp
@@ -33,6 +34,31 @@ find_package(catkin REQUIRED COMPONENTS
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
 catkin_python_setup()
 
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## Generate messages in the 'msg' folder
+add_message_files(
+  FILES
+  ClusterInfo.msg
+)
+
+## Generate services in the 'srv' folder
+add_service_files(
+  FILES
+  ClusterInfoArray.srv
+  FilterParams.srv
+  SnapPicture.srv
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  geometry_msgs
+  std_msgs
+)
+
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -43,6 +69,7 @@ catkin_package(
   interbotix_xs_msgs
   apriltag_ros
   cv_bridge
+  message_runtime
   pcl_conversions
   pcl_ros
   roscpp

--- a/interbotix_perception_toolbox/interbotix_perception_modules/msg/ClusterInfo.msg
+++ b/interbotix_perception_toolbox/interbotix_perception_modules/msg/ClusterInfo.msg
@@ -1,0 +1,11 @@
+# This message is used specifically in the interbotix_perception_modules package
+#
+# Message that holds information about each cluster
+
+string frame_id                     # parent frame of the cluster (usually 'camera_depth_optical_frame' or similar)
+geometry_msgs/Point position        # x, y, z position of the cluster
+float32 yaw                         # yaw [rad] of the cluster; x-axis of the cluster should align
+                                    # with the major-axis of a best-fit ellipse (currently not supported)
+std_msgs/ColorRGBA color            # average RGB values (0 - 255) for the whole cluster
+geometry_msgs/Point min_z_point     # point with the min 'z' value of the cluster
+int32 num_points                    # number of points in the cluster

--- a/interbotix_perception_toolbox/interbotix_perception_modules/package.xml
+++ b/interbotix_perception_toolbox/interbotix_perception_modules/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>apriltag_ros</build_depend>
   <build_depend>cv_bridge</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>roscpp</build_depend>
@@ -23,6 +24,7 @@
   <build_depend>std_srvs</build_depend>
   <build_export_depend>apriltag_ros</build_export_depend>
   <build_export_depend>cv_bridge</build_export_depend>
+  <build_export_depend>message_generation</build_export_depend>
   <build_export_depend>pcl_conversions</build_export_depend>
   <build_export_depend>pcl_ros</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
@@ -33,6 +35,7 @@
   <build_export_depend>std_srvs</build_export_depend>
   <exec_depend>apriltag_ros</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
   <exec_depend>pcl_conversions</exec_depend>
   <exec_depend>pcl_ros</exec_depend>
   <exec_depend>python_qt_binding</exec_depend>

--- a/interbotix_perception_toolbox/interbotix_perception_modules/scripts/picture_snapper
+++ b/interbotix_perception_toolbox/interbotix_perception_modules/scripts/picture_snapper
@@ -6,7 +6,7 @@ import rospy
 import threading
 from cv_bridge import CvBridge
 from sensor_msgs.msg import Image
-from interbotix_perception_modules.srv import SnapPicture, SnapPictureResponse
+from interbotix_xs_msgs.srv import SnapPicture, SnapPictureResponse
 
 # To start this application, open a terminal on the robot and type...
 #   'roslaunch interbotix_perception_modules picture_snapper.launch'

--- a/interbotix_perception_toolbox/interbotix_perception_modules/src/perception_pipeline.cpp
+++ b/interbotix_perception_toolbox/interbotix_perception_modules/src/perception_pipeline.cpp
@@ -16,16 +16,16 @@
 #include <pcl/common/common.h>
 #include <pcl/common/transforms.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include "interbotix_xs_msgs/FilterParams.h"
-#include "interbotix_xs_msgs/ClusterInfo.h"
-#include "interbotix_xs_msgs/ClusterInfoArray.h"
+#include "interbotix_perception_modules/FilterParams.h"
+#include "interbotix_perception_modules/ClusterInfo.h"
+#include "interbotix_perception_modules/ClusterInfoArray.h"
 
 typedef pcl::PointXYZRGB PointT;
 
 ros::Publisher pub_pc_obj, pub_pc_filter, pub_marker_obj, pub_marker_crop;
 visualization_msgs::Marker marker_obj, marker_crop;
 sensor_msgs::PointCloud2ConstPtr input;
-std::vector<interbotix_xs_msgs::ClusterInfo> cluster_info_vector;
+std::vector<interbotix_perception_modules::ClusterInfo> cluster_info_vector;
 bool enable_pipeline = true;
 std::string cloud_topic;
 float x_filter_min, y_filter_min, z_filter_min;
@@ -160,7 +160,7 @@ void perception_pipeline()
     pub_marker_obj.publish(marker_obj);
 
     // Save a ClusterInfo message with info on the cluster
-    interbotix_xs_msgs::ClusterInfo ci_msg;
+    interbotix_perception_modules::ClusterInfo ci_msg;
     ci_msg.frame_id = input->header.frame_id;
     ci_msg.position.x = cntrd.x;
     ci_msg.position.y = cntrd.y;
@@ -191,7 +191,7 @@ void cloud_cb(const sensor_msgs::PointCloud2ConstPtr& pointcloud)
 // @param req - Custom FilterParams service request containing the parameters to change
 // @param res - Custom FitlerParams service response (empty)
 // @return <bool> - true if service executed successfully
-bool srv_set_filter_params(interbotix_xs_msgs::FilterParams::Request& req, interbotix_xs_msgs::FilterParams::Response& res)
+bool srv_set_filter_params(interbotix_perception_modules::FilterParams::Request& req, interbotix_perception_modules::FilterParams::Response& res)
 {
   voxel_leaf_size = req.voxel_leaf_size;
   x_filter_min = req.x_filter_min;
@@ -214,7 +214,7 @@ bool srv_set_filter_params(interbotix_xs_msgs::FilterParams::Request& req, inter
 // @param req - Custom ClusterInfoArray service request (empty)
 // @param res - Custom ClusterInfoArray service response containing a list of ClusterInfo messages for each cluster found
 // @return <bool> - true if service executed successfully
-bool srv_get_cluster_positions(interbotix_xs_msgs::ClusterInfoArray::Request& req, interbotix_xs_msgs::ClusterInfoArray::Response& res)
+bool srv_get_cluster_positions(interbotix_perception_modules::ClusterInfoArray::Request& req, interbotix_perception_modules::ClusterInfoArray::Response& res)
 {
   if (!enable_pipeline)
     perception_pipeline();

--- a/interbotix_perception_toolbox/interbotix_perception_modules/srv/ClusterInfoArray.srv
+++ b/interbotix_perception_toolbox/interbotix_perception_modules/srv/ClusterInfoArray.srv
@@ -1,0 +1,7 @@
+# This service is used specifically in the interbotix_perception_modules package
+#
+# List of ClusterInfo messages. The length of the list should correspond to the
+# number of objects seen by the camera
+
+---
+interbotix_perception_modules/ClusterInfo[] clusters

--- a/interbotix_perception_toolbox/interbotix_perception_modules/srv/FilterParams.srv
+++ b/interbotix_perception_toolbox/interbotix_perception_modules/srv/FilterParams.srv
@@ -1,0 +1,19 @@
+# This service is used specifically in the interbotix_perception_modules package
+#
+# Parameters used to tune the various PCL Pointcloud filters
+
+float32 x_filter_min            # minimum value [m] along the x axis beyond which all points will be cropped when doing Crop Box Filtering
+float32 x_filter_max            # maximum value [m] along the x axis beyond which all points will be cropped when doing Crop Box Filtering
+float32 y_filter_min            # minimum value [m] along the y axis beyond which all points will be cropped when doing Crop Box Filtering
+float32 y_filter_max            # maximum value [m] along the y axis beyond which all points will be cropped when doing Crop Box Filtering
+float32 z_filter_min            # minimum value [m] along the z axis beyond which all points will be cropped when doing Crop Box Filtering
+float32 z_filter_max            # maximum value [m] along the z axis beyond which all points will be cropped when doing Crop Box Filtering
+float32 voxel_leaf_size         # voxel leaf size [m] for the x, y, and z axes when doing Voxel Filtering
+int32 plane_max_iter            # maximum number of iterations the algorithm should go when when doing Planar Segmentation
+float32 plane_dist_thresh       # distance [m] perpendicular from the planar model outside of which points should not be segmented out when doing Planar Segmentation
+float32 ror_radius_search       # desired search radius when doing Radius Outlier Removal
+int32 ror_min_neighbors         # minimum number of neighbors a point should have to not be cropped out when doing Radius Outlier Removal
+float32 cluster_tol             # any point within this distance [m] will be considered part of the same cluster
+int32 cluster_min_size          # minimum number of points a cluster must have to be considered a cluster
+int32 cluster_max_size          # maximum number of points a cluster can have to be considered a cluster
+---

--- a/interbotix_perception_toolbox/interbotix_perception_modules/srv/SnapPicture.srv
+++ b/interbotix_perception_toolbox/interbotix_perception_modules/srv/SnapPicture.srv
@@ -1,0 +1,14 @@
+# This service is used specifically in the interbotix_perception_modules package
+#
+# Save the latest rgb picture with the specified name
+#
+# Request consists of:
+#   filename : name of file in which to save image including extension (.jpg)
+#
+# Response consists of:
+#    success : boolean indication of service success
+
+string filename
+---
+bool success
+string filepath


### PR DESCRIPTION
Moved ClusterInfo.msg, ClusterInfoArray.srv, FilterParams.srv, and SnapPicture.srv back to interbotix_perception_modules, as the perception messages should be independent of the platform.