### PR TITLE
[rpi_modules] Add back rpi messages

### DIFF
--- a/interbotix_rpi_toolbox/interbotix_rpi_modules/CMakeLists.txt
+++ b/interbotix_rpi_toolbox/interbotix_rpi_modules/CMakeLists.txt
@@ -5,7 +5,7 @@ project(interbotix_rpi_modules)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  interbotix_xs_msgs
+  message_generation
   rospy
   std_msgs
 )
@@ -19,13 +19,29 @@ find_package(catkin REQUIRED COMPONENTS
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
 catkin_python_setup()
 
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## Generate messages in the 'msg' folder
+add_message_files(
+   FILES
+   PixelCommands.msg
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+   DEPENDENCIES
+   std_msgs
+)
+
 ###################################
 ## catkin specific configuration ##
 ###################################
 ## The catkin_package macro generates cmake config files for your package
 ## Declare things to be passed to dependent projects
 catkin_package(
-   CATKIN_DEPENDS interbotix_xs_msgs rospy std_msgs
+   CATKIN_DEPENDS message_runtime rospy std_msgs
 )
 
 #############

--- a/interbotix_rpi_toolbox/interbotix_rpi_modules/msg/PixelCommands.msg
+++ b/interbotix_rpi_toolbox/interbotix_rpi_modules/msg/PixelCommands.msg
@@ -1,0 +1,13 @@
+# This message is used specifically in the interbotix_rpi_modules package
+#
+# Configure NeoPixel Leds on a Raspberry Pi
+
+string cmd_type       # Either 'pulse', 'blink', 'brightness', or 'color'.
+                      # Note that the 'pulse' and 'brightness' options will
+                      # affect all Leds even if 'set_all_leds' is set to False.
+bool set_all_leds     # Set to True to configure all LEDs
+uint8 pixel           # Index of NeoPixel to change (only considered if 'set_all_leds' is false)
+uint32 color			    # Value indicates Color to be used (HEX - RGB)
+uint8 brightness      # Value indicates LED brightness level (0-255)
+uint32 period			    # time delay for blink or pulse (milliseconds)
+uint8 iterations		  # iterations = number of iterations for blink or pulse

--- a/interbotix_rpi_toolbox/interbotix_rpi_modules/package.xml
+++ b/interbotix_rpi_toolbox/interbotix_rpi_modules/package.xml
@@ -9,15 +9,14 @@
   <author email="solomon@trossenrobotics.com">Solomon Wiznitzer</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>interbotix_xs_msgs</build_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
-  <build_export_depend>interbotix_xs_msgs</build_export_depend>
+  <exec_depend>message_runtime</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>interbotix_xs_msgs</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Moved PixelCommands.msg back to interbotix_rpi_modules, as the rpi messages should be independent of the platform.