### PR TITLE
Arm.py accepting integer inputs - final position is rounded to 0

### DIFF
--- a/interbotix_xs_toolbox/interbotix_xs_modules/interbotix_xs_modules/xs_robot/arm.py
+++ b/interbotix_xs_toolbox/interbotix_xs_modules/interbotix_xs_modules/xs_robot/arm.py
@@ -461,6 +461,7 @@ class InterbotixArmXSInterface:
         :details: Note that if a moving_time or accel_time is specified, the changes affect ALL the
             arm joints, not just the specified one
         """
+        position = float(position)
         self.core.get_logger().debug(
             f'Setting joint {joint_name} to position={position}'
         )


### PR DESCRIPTION
In arm.py, when calling set_single_joint_position(), the function would accept integers, causing the final position to be rounded down to 0. The joint would end up moving back to the home position, rather than the intended location.

This was tested on the PincherX-100 through the Python API. I tested integers from -3 to 3 and the resulting position was always 0. Using floats [-3.0, -2.0, -1.0 , ... , 3.0] worked as intended