### PR TITLE
fix overwriting _XSLOCOBOT_MODELS

### DIFF
--- a/interbotix_xs_toolbox/interbotix_xs_modules/interbotix_xs_modules/xs_common/xs_common.py
+++ b/interbotix_xs_toolbox/interbotix_xs_modules/interbotix_xs_modules/xs_common/xs_common.py
@@ -54,7 +54,7 @@ _XSLOCOBOT_MODELS = (
 )
 
 # Tuple of valid Interbotix Turret models
-_XSLOCOBOT_MODELS = (
+_XSTURRET_MODELS = (
     'pxxls_cam',
     'pxxls',
     'vxxmd',
@@ -76,7 +76,7 @@ def get_interbotix_xslocobot_models() -> Tuple[str]:
 
 def get_interbotix_xsturret_models() -> Tuple[str]:
     """Get the tuple of valid Interbotix Turret models."""
-    return _XSLOCOBOT_MODELS
+    return _XSTURRET_MODELS
 
 
 def get_interbotix_xsarm_joints(robot_model: str) -> List[str]:


### PR DESCRIPTION
Variable `_XSLOCOBOT_MODELS` got overridden by the turret models. Created a new variable to fix this.