### PR TITLE
Add missing xs modules dependencies

### DIFF
--- a/interbotix_xs_toolbox/interbotix_xs_modules/interbotix_xs_modules/xs_robot/core.py
+++ b/interbotix_xs_toolbox/interbotix_xs_modules/interbotix_xs_modules/xs_robot/core.py
@@ -30,7 +30,6 @@
 
 import copy
 
-from rclpy.callback_groups import ReentrantCallbackGroup
 from threading import Lock
 from typing import (
     Dict,
@@ -56,6 +55,7 @@ from interbotix_common_modules.common_robot.robot import (
     create_interbotix_global_node,
 )
 import rclpy
+from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.duration import Duration
 from rclpy.logging import LoggingSeverity, set_logger_level
 from sensor_msgs.msg import JointState

--- a/interbotix_xs_toolbox/interbotix_xs_modules/package.xml
+++ b/interbotix_xs_toolbox/interbotix_xs_modules/package.xml
@@ -8,13 +8,27 @@
   <license>BSD-3-Clause</license>
   <author email="trsupport@trossenrobotics.com">Solomon Wiznitzer</author>
 
-  <exec_depend>interbotix_xs_msgs</exec_depend>
+  <exec_depend>action_msgs</exec_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>interbotix_common_modules</exec_depend>
+  <exec_depend>interbotix_common_modules</exec_depend>
+  <!-- <exec_depend>interbotix_slate_msgs</exec_depend> -->
+  <exec_depend>interbotix_xs_msgs</exec_depend>
   <exec_depend>interbotix_xs_sdk</exec_depend>
-  <exec_depend>tf_transformations</exec_depend>
+  <!-- <exec_depend>irobot_create_msgs</exec_depend> -->
   <!-- <exec_depend>kobuki_ros_interfaces</exec_depend> -->
-  <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>nav2_msgs</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>tf_transformations</exec_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
This PR adds missing dependencies to the interbotix_xs_modules package manifest.