### PR TITLE
[xs_modules] Reject NaN joint commands

### DIFF
--- a/interbotix_xs_toolbox/interbotix_xs_modules/interbotix_xs_modules/xs_robot/arm.py
+++ b/interbotix_xs_toolbox/interbotix_xs_modules/interbotix_xs_modules/xs_robot/arm.py
@@ -329,7 +329,7 @@ class InterbotixArmXSInterface:
 
         # Reject any commands containing NaN values
         if any(math.isnan(elem) for elem in positions):
-            self.core.get_node().logwarn('NaN values detected in joint positions')
+            self.core.get_node().logwarn('Rejecting NaN values in position command')
             return False
 
         theta_list = [int(elem * 1000) / 1000.0 for elem in positions]
@@ -360,6 +360,12 @@ class InterbotixArmXSInterface:
         self.core.get_node().logdebug(
             f"Checking joint '{joint_name}' limits for {position=}"
         )
+
+        # Reject any commands containing NaN values
+        if math.isnan(position):
+            self.core.get_node().logwarn('Rejecting NaN value in position command')
+            return False
+
         theta = int(position * 1000) / 1000.0
         speed = abs(
             theta - self.joint_commands[self.info_index_map[joint_name]]

--- a/interbotix_xs_toolbox/interbotix_xs_modules/interbotix_xs_modules/xs_robot/arm.py
+++ b/interbotix_xs_toolbox/interbotix_xs_modules/interbotix_xs_modules/xs_robot/arm.py
@@ -326,6 +326,12 @@ class InterbotixArmXSInterface:
         :return: `True` if all positions are within limits; `False` otherwise
         """
         self.core.get_node().logdebug(f'Checking joint limits for {positions=}')
+
+        # Reject any commands containing NaN values
+        if any(math.isnan(elem) for elem in positions):
+            self.core.get_node().logwarn('NaN values detected in joint positions')
+            return False
+
         theta_list = [int(elem * 1000) / 1000.0 for elem in positions]
         speed_list = [
             abs(goal - current) / float(self.moving_time)


### PR DESCRIPTION
This PR adds a check to the xs_modules arm module where the module will now fail joint limit checks if the command contains a NaN value.