### PR TITLE
Add missing test dependency

### DIFF
--- a/interbotix_xs_toolbox/interbotix_xs_ros_control/package.xml
+++ b/interbotix_xs_toolbox/interbotix_xs_ros_control/package.xml
@@ -26,6 +26,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>hardware_interface</test_depend>
   <test_depend>rclcpp</test_depend>
+  <test_depend>ros2_control_test_assets</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/interbotix_xs_toolbox/interbotix_xs_ros_control/package.xml
+++ b/interbotix_xs_toolbox/interbotix_xs_ros_control/package.xml
@@ -15,6 +15,7 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>ros2_control_test_assets</depend>
   <depend>ros2_controllers</depend>
   <depend>ros2controlcli</depend>
   <depend>interbotix_xs_msgs</depend>
@@ -26,7 +27,6 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>hardware_interface</test_depend>
   <test_depend>rclcpp</test_depend>
-  <test_depend>ros2_control_test_assets</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/interbotix_xs_toolbox/interbotix_xs_ros_control/package.xml
+++ b/interbotix_xs_toolbox/interbotix_xs_ros_control/package.xml
@@ -15,7 +15,6 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
-  <depend>ros2_control_test_assets</depend>
   <depend>ros2_controllers</depend>
   <depend>ros2controlcli</depend>
   <depend>interbotix_xs_msgs</depend>
@@ -26,6 +25,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>hardware_interface</test_depend>
+  <test_depend>ros2_control_test_assets</test_depend>
   <test_depend>rclcpp</test_depend>
 
   <export>


### PR DESCRIPTION
Fixes https://github.com/Interbotix/interbotix_ros_manipulators/issues/259

This PR adds `ros2_control_test_assets` to the `interbotix_xs_ros_control` package's test depends.